### PR TITLE
order by pushed_at instead of added_at

### DIFF
--- a/circle.5s.py
+++ b/circle.5s.py
@@ -75,7 +75,7 @@ def user_builds(branches):
             builds.append(running_build)
 
         if 'recent_builds' in info:
-            for build in sorted(info['recent_builds'], key = itemgetter('added_at'), reverse = True):
+            for build in sorted(info['recent_builds'], key = itemgetter('pushed_at'), reverse = True):
                 build['branch'] = name
                 build['reponame'] = info['reponame']
                 builds.append(build)
@@ -101,7 +101,7 @@ if __name__ == '__main__':
 
     user_branches = user_branches()
     user_builds = user_builds(user_branches)
-    latest_builds = sorted(user_builds, key = itemgetter('added_at'), reverse = True)
+    latest_builds = sorted(user_builds, key = itemgetter('pushed_at'), reverse = True)
     builds = latest_builds[:10]
     if len(builds) == 0:
         print 'No Builds'


### PR DESCRIPTION
Changing the state of a build (e.g. by canceling it) seems to change the `added_at` timestamp. This changes the sorting to be by `pushed_at`, so your most recent build should show up first. 

I ran two builds, and cancelled the earlier one. I would expect to see the still running one at the top.
Sorted by `added_at`, this does not happen. Sorted by `pushed_at`, it does:
![image](https://cloud.githubusercontent.com/assets/4108849/19949202/a174b534-a10d-11e6-8d1c-1f691a38932c.png)
